### PR TITLE
Correct typo in vector addition

### DIFF
--- a/notes/1.02 Linear Algebra.md
+++ b/notes/1.02 Linear Algebra.md
@@ -74,7 +74,7 @@ So a column vector $x$ can be represented as a row vector with $x^T$.
 
 Vectors are added by adding the individual corresponding components:
 
-$$ \begin{bmatrix} 6 \\ 2 \end{bmatrix} + \begin{bmatrix} -4 \\ 4 \end{bmatrix} = \begin{bmatrix} 6 + -4 \\ 2 + 2 \end{bmatrix} = \begin{bmatrix} 2 \\ 2 \end{bmatrix} $$
+$$ \begin{bmatrix} 6 \\ 2 \end{bmatrix} + \begin{bmatrix} -4 \\ 4 \end{bmatrix} = \begin{bmatrix} 6 + -4 \\ 2 + 4 \end{bmatrix} = \begin{bmatrix} 2 \\ 6 \end{bmatrix} $$
 
 #### Multiplying a vector by a scalar
 


### PR DESCRIPTION
Current version of the vector addition example reads: 

[6, 2] + [-4, 4] = [6 + -4, 2 + 2] = [2, 2]

and should read:

[6, 2] + [-4, 4] = [6 + -4, 2 + 4] = [2, 6]

Unless I am mistaken?
