### PR TITLE
Minor change in linear algebra section

### DIFF
--- a/notes/1.02 Linear Algebra.md
+++ b/notes/1.02 Linear Algebra.md
@@ -789,7 +789,7 @@ We say that a matrix is __upper-triangular__ if all of its elements below the di
 
 Similarly, a matrix is __lower-triangular__ if all of its elements above the diagonal are zero.
 
-A matrix is __triangular__ if it is both upper-triangular and lower-triangular.
+A matrix is __diagonal__ if it is both upper-triangular and lower-triangular.
 
 ### Some properties of matrices
 


### PR DESCRIPTION
A triangular matrix which is both upper triangular and lower triangular is a _diagonal_ matrix. I think this was a typo from the intended wording.
