### PR TITLE
Fix an error in Probability note

### DIFF
--- a/notes/1.04 Probability.md
+++ b/notes/1.04 Probability.md
@@ -511,7 +511,7 @@ $$
 If random variables $X$ and $Y$ are independent, then:
 
 $$
-\Var(X+Y) = \Var(X)\Var(Y)
+\Var(X+Y) = \Var(X) + \Var(Y)
 $$
 
 ### Covariance


### PR DESCRIPTION
For two random variables X and Y,

Var(X + Y) should be Var(X) + Var(Y) instead of Var(x)Var(Y).